### PR TITLE
Fix autoloader with rename of lib => src

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "Teapot": "lib" }
+        "psr-0": { "Teapot": "src" }
     }
 }


### PR DESCRIPTION
When the lib folder was renamed to src the autoloader in composer was broken - this should fix it :)
