### PR TITLE
Update README examples to not throw a syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ This becomes:
     <?php
     use \Teapot\StatusCode;
     ...
-    $this->assertEquals(StatusCode:OK, $response->getStatusCode());
+    $this->assertEquals(StatusCode::OK, $response->getStatusCode());
 
 While this is a trivial example, the additional verbosity of the code is clearer with other HTTP status codes:
 
     <?php
     use \Teapot\StatusCode;
     $code = $response->getStatusCode();
-    $this->assertNotEquals(StatusCode:NOT_FOUND, $code);
-    $this->assertNotEquals(StatusCode:FORBIDDEN, $code);
-    $this->assertNotEquals(StatusCode:MOVED_PERMANENTLY, $code);
-    $this->assertEquals(StatusCode:CREATED, $code);
+    $this->assertNotEquals(StatusCode::NOT_FOUND, $code);
+    $this->assertNotEquals(StatusCode::FORBIDDEN, $code);
+    $this->assertNotEquals(StatusCode::MOVED_PERMANENTLY, $code);
+    $this->assertEquals(StatusCode::CREATED, $code);
 
 As `StatusCode` is an interface without any methods, you can directly implement it if you prefer:
 


### PR DESCRIPTION
I remember a time when I was a complete n00bie and would copy and paste code straight from the examples, and then complain when it didn't work exactly how I expected it to.

Everyone overlooks the simplest of things from time to time :+1: