### PR TITLE
Fix: Remove leading slash when importing, remove unused imports

### DIFF
--- a/src/Teapot/HttpException.php
+++ b/src/Teapot/HttpException.php
@@ -14,7 +14,7 @@
  */
 namespace Teapot;
 
-use \Teapot\StatusCode;
+use Teapot\StatusCode;
 
 /**
  * Simple Exception to represent http-based Exceptions

--- a/src/Teapot/StatusCode.php
+++ b/src/Teapot/StatusCode.php
@@ -24,7 +24,7 @@
  */
 namespace Teapot;
 
-use \Teapot\StatusCode\Http;
+use Teapot\StatusCode\Http;
 
 /**
  * Interface representing standard HTTP status codes. These codes are

--- a/src/Teapot/StatusCode/All.php
+++ b/src/Teapot/StatusCode/All.php
@@ -20,8 +20,6 @@
  */
 namespace Teapot\StatusCode;
 
-use Teapot\StatusCode\Http;
-use Teapot\StatusCode\WebDAV;
 use Teapot\StatusCode\RFC\Draft;
 use Teapot\StatusCode\RFC\PEP;
 use Teapot\StatusCode\RFC\RFC2295 as ContentNegotiation;

--- a/src/Teapot/StatusCode/All.php
+++ b/src/Teapot/StatusCode/All.php
@@ -20,15 +20,15 @@
  */
 namespace Teapot\StatusCode;
 
-use \Teapot\StatusCode\Http;
-use \Teapot\StatusCode\WebDAV;
-use \Teapot\StatusCode\RFC\Draft;
-use \Teapot\StatusCode\RFC\PEP;
-use \Teapot\StatusCode\RFC\RFC2295 as ContentNegotiation;
-use \Teapot\StatusCode\RFC\RFC2324 as HyperTextCoffeePotControlProtocol;
-use \Teapot\StatusCode\RFC\RFC2326 as Rtsp;
-use \Teapot\StatusCode\RFC\RFC2817 as TLS;
-use \Teapot\StatusCode\RFC\RFC3229 as HttpDeltas;
+use Teapot\StatusCode\Http;
+use Teapot\StatusCode\WebDAV;
+use Teapot\StatusCode\RFC\Draft;
+use Teapot\StatusCode\RFC\PEP;
+use Teapot\StatusCode\RFC\RFC2295 as ContentNegotiation;
+use Teapot\StatusCode\RFC\RFC2324 as HyperTextCoffeePotControlProtocol;
+use Teapot\StatusCode\RFC\RFC2326 as Rtsp;
+use Teapot\StatusCode\RFC\RFC2817 as TLS;
+use Teapot\StatusCode\RFC\RFC3229 as HttpDeltas;
 
 /**
  * Interface representing extended HTTP status codes. These codes are

--- a/src/Teapot/StatusCode/Http.php
+++ b/src/Teapot/StatusCode/Http.php
@@ -23,9 +23,9 @@
  */
 namespace Teapot\StatusCode;
 
-use \Teapot\StatusCode\RFC\RFC2616;
-use \Teapot\StatusCode\RFC\RFC2324;
-use \Teapot\StatusCode\RFC\RFC2774;
+use Teapot\StatusCode\RFC\RFC2616;
+use Teapot\StatusCode\RFC\RFC2324;
+use Teapot\StatusCode\RFC\RFC2774;
 
 /**
  * Interface representing standard and extended HTTP status codes. These codes are

--- a/src/Teapot/StatusCode/RFC/Draft.php
+++ b/src/Teapot/StatusCode/RFC/Draft.php
@@ -20,7 +20,7 @@
  */
 namespace Teapot\StatusCode\RFC;
 
-use \Teapot\StatusCode\RFC\RFC2616;
+use Teapot\StatusCode\RFC\RFC2616;
 
 /**
  * Interface representing extended HTTP status codes for Draft codes. These codes are

--- a/src/Teapot/StatusCode/RFC/Draft.php
+++ b/src/Teapot/StatusCode/RFC/Draft.php
@@ -20,8 +20,6 @@
  */
 namespace Teapot\StatusCode\RFC;
 
-use Teapot\StatusCode\RFC\RFC2616;
-
 /**
  * Interface representing extended HTTP status codes for Draft codes. These codes are
  * represented as an interface so that developers may implement it and then use

--- a/src/Teapot/StatusCode/Vendor.php
+++ b/src/Teapot/StatusCode/Vendor.php
@@ -21,7 +21,6 @@
 namespace Teapot\StatusCode;
 
 use Teapot\StatusCode\Vendor\Apache;
-use Teapot\StatusCode\Vendor\Cloudflare;
 use Teapot\StatusCode\Vendor\Microsoft;
 use Teapot\StatusCode\Vendor\Nginx;
 use Teapot\StatusCode\Vendor\Twitter;

--- a/src/Teapot/StatusCode/Vendor.php
+++ b/src/Teapot/StatusCode/Vendor.php
@@ -20,11 +20,11 @@
  */
 namespace Teapot\StatusCode;
 
-use \Teapot\StatusCode\Vendor\Apache;
-use \Teapot\StatusCode\Vendor\Cloudflare;
-use \Teapot\StatusCode\Vendor\Microsoft;
-use \Teapot\StatusCode\Vendor\Nginx;
-use \Teapot\StatusCode\Vendor\Twitter;
+use Teapot\StatusCode\Vendor\Apache;
+use Teapot\StatusCode\Vendor\Cloudflare;
+use Teapot\StatusCode\Vendor\Microsoft;
+use Teapot\StatusCode\Vendor\Nginx;
+use Teapot\StatusCode\Vendor\Twitter;
 
 /**
  * Interface representing extended HTTP status codes for vendor-specific codes.

--- a/src/Teapot/StatusCode/WebDAV.php
+++ b/src/Teapot/StatusCode/WebDAV.php
@@ -20,10 +20,10 @@
  */
 namespace Teapot\StatusCode;
 
-use \Teapot\StatusCode\RFC\RFC2518;
-use \Teapot\StatusCode\RFC\RFC3648;
-use \Teapot\StatusCode\RFC\RFC4918;
-use \Teapot\StatusCode\RFC\RFC5842;
+use Teapot\StatusCode\RFC\RFC2518;
+use Teapot\StatusCode\RFC\RFC3648;
+use Teapot\StatusCode\RFC\RFC4918;
+use Teapot\StatusCode\RFC\RFC5842;
 
 /**
  * Interface representing extended HTTP status codes for WebDAV. These codes are


### PR DESCRIPTION
This PR

* [x] removes the leading slash when importing namespaces
* [x] removes unused imports