### PR TITLE
Add installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ throw new HttpException(
 );
 ```
 
+### Installation
+
+Run the following command.
+
+```sh
+composer require shrikeh/teapot
+ ```
+
 ### Coding Standards
 
 The entire library is intended to be [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md "PSR-0"), [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md "PSR-1") and [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md "PSR-2") compliant.


### PR DESCRIPTION
This will allow users to install the library without the need to find it on packagist.

```sh
$ composer require shrikeh/teapot
Using version ^1.0 for shrikeh/teapot
./composer.json has been updated
Loading composer repositories with package information
...
```