### PR TITLE
No longer PSR-0; updated Standards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ composer require shrikeh/teapot
 
 ### Coding Standards
 
-The entire library is intended to be [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md "PSR-0"), [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md "PSR-1") and [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md "PSR-2") compliant.
+The entire library is intended to be [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4.md "PSR-4"), [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md "PSR-1") and [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md "PSR-2") compliant.
 
 ### Get in touch
 


### PR DESCRIPTION
It is PSR-4 only now the `Teapot` directory has been removed.